### PR TITLE
Fix permissions on files

### DIFF
--- a/time_weather.sh
+++ b/time_weather.sh
@@ -93,7 +93,7 @@ rm -f "$ZIP_FILE"
 echo "Setting permissions and ownership for extracted files..."
 find "$SOUNDS_DIR" -type d -exec chown asterisk:asterisk {} \;
 find "$SOUNDS_DIR" -type d -exec chmod 775 {} \;
-find "$SOUNDS_DIR" -name "*.gsm" -exec chmod 664 {} \;
+find "$SOUNDS_DIR" -name "*.gsm" -exec chmod 644 {} \;
 find "$SOUNDS_DIR" -name "*.gsm" -exec chown asterisk:asterisk {} \;
 
 # Set up a cron job for hourly announcements


### PR DESCRIPTION
Simply adjust permissions so they are owned by asterisk:asterisk and the audio files have the proper permissions. This will fix the DTMF failure that was reported on discord.

a simple test can be done with a dtmf command being added to rpt.conf such as the following

C1 = cmd,/usr/local/sbin/saytime.pl 77511 546054